### PR TITLE
Update base image to alpine 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.19
 LABEL maintainer "Jonathan Gazeley"
 
 RUN apk add --no-cache postfix rsyslog supervisor \


### PR DESCRIPTION
3.16 security support ends May 23rd 2024

Tested doing a basic test from my laptop to relay a mail to my smtp upstream server
```
➜  telnet 127.0.0.1 2525
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.
220 scamorza.doesnotexists.fr ESMTP Postfix
EHLO dsdsd.cf
250-scamorza.alcmeon.com
250-PIPELINING
250-SIZE 10240000
250-VRFY
250-ETRN
250-ENHANCEDSTATUSCODES
250-8BITMIME
250-DSN
250 CHUNKING
MAIL FROM: me@doesnotexists.fr
250 2.1.0 Ok
RCPT TO: baptistemm@heya.com 
250 2.1.5 Ok
DATA
354 End data with <CR><LF>.<CR><LF>
From: me@doesnotexists.fr
To: baptistemm@heya.com 
Subject: Telnet email

Testing I can connect to a local smtp server
.
250 2.0.0 Ok: queued as DC9D14A500D3
```