### PR TITLE
Logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.19
 LABEL maintainer "Jonathan Gazeley"
 
-RUN apk add --no-cache postfix rsyslog supervisor \
+RUN apk add --no-cache postfix supervisor \
     && /usr/bin/newaliases
 
 COPY . /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.19
 LABEL maintainer "Jonathan Gazeley"
 
-RUN apk add --no-cache postfix supervisor \
+RUN apk add --no-cache postfix \
     && /usr/bin/newaliases
 
 COPY . /

--- a/etc/rsyslog.conf
+++ b/etc/rsyslog.conf
@@ -1,6 +1,0 @@
-# http://www.rsyslog.com/doc/
-
-$ModLoad immark.so         # provide --MARK-- message capability
-
-$IncludeConfig /etc/rsyslog.d/*.conf
-

--- a/etc/rsyslog.d/imux.conf
+++ b/etc/rsyslog.d/imux.conf
@@ -1,3 +1,0 @@
-# Input modules
-module(load="imuxsock")
-input(type="imuxsock" Socket="/var/run/rsyslog/dev/log" CreatePath="on")

--- a/etc/rsyslog.d/maillog.conf
+++ b/etc/rsyslog.d/maillog.conf
@@ -1,1 +1,0 @@
-mail.*     -/var/log/maillog

--- a/etc/rsyslog.d/stdout.conf
+++ b/etc/rsyslog.d/stdout.conf
@@ -1,3 +1,0 @@
-$ModLoad omstdout.so       # provide messages to stdout
-
-*.* :omstdout:             # send everything to stdout

--- a/etc/supervisor.d/postfix.ini
+++ b/etc/supervisor.d/postfix.ini
@@ -1,6 +1,0 @@
-[program:postfix]
-process_name	= master
-directory	= /etc/postfix
-command		= /usr/sbin/postfix -c /etc/postfix start
-startsecs	= 0
-autorestart = false

--- a/etc/supervisor.d/rsyslog.ini
+++ b/etc/supervisor.d/rsyslog.ini
@@ -1,7 +1,0 @@
-[program:rsyslog]
-command=/usr/sbin/rsyslogd -n
-numprocs=1
-autostart=true
-autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0

--- a/smtp-relay.sh
+++ b/smtp-relay.sh
@@ -31,4 +31,7 @@ postconf 'smtputf8_enable = no' || exit 1
 # This makes sure the message id is set. If this is set to no dkim=fail will happen.
 postconf 'always_add_missing_headers = yes' || exit 1
 
+# Log to stdout
+postconf 'maillog_file = /dev/stdout' || exit 1
+
 /usr/bin/supervisord -n

--- a/smtp-relay.sh
+++ b/smtp-relay.sh
@@ -34,4 +34,5 @@ postconf 'always_add_missing_headers = yes' || exit 1
 # Log to stdout
 postconf 'maillog_file = /dev/stdout' || exit 1
 
-/usr/bin/supervisord -n
+# Start postfix
+postfix start-fg


### PR DESCRIPTION
* Configure Postfix to log directly to `/dev/stdout`, so we can drop rsyslog
* Drop supervisord as Postfix is now the only process