### PR TITLE
Feature_add-smtp_use_tls_option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ This image supports the following enironment variables. All are **required**.
 | `SMTP_RELAY_PASSWORD`      | Password for upstream SMTP relay server                             | `pAsSwOrD`                |
 | `SMTP_RELAY_MYHOSTNAME`    | Hostname of this SMTP relay                                         | `smtp-relay.yourhost.com` |
 | `SMTP_RELAY_MYNETWORKS`    | Comma-separated list of local networks that can use this SMTP relay | `127.0.0.0/8,10.0.0.0/8`  |
-| `SMTP_RELAY_WRAPPERMODE`   | Request postfix connects using SUBMISSIONS/SMTPS protocol instead of STARTTLS | `no`                      |
+| `SMTP_RELAY_WRAPPERMODE`   | Request postfix connects using SUBMISSIONS/SMTPS protocol instead of STARTTLS | `no`            |
 | `SMTP_TLS_SECURITY_LEVEL`  | default SMTP TLS security level for the Postfix SMTP client         | `""`                      |
+| `SMTP_USE_TLS`             | Define TLS usage to secure communication between mail servers       | `no`                      |
 
 # Quickstart
 Run on docker

--- a/smtp-relay.sh
+++ b/smtp-relay.sh
@@ -17,6 +17,7 @@ rm /etc/postfix/sasl_passwd || exit 1
 postconf 'smtp_sasl_auth_enable = yes' || exit 1
 postconf 'smtp_sasl_password_maps = lmdb:/etc/postfix/sasl_passwd' || exit 1
 postconf 'smtp_sasl_security_options =' || exit 1
+postconf "smtp_use_tls = ${SMTP_USE_TLS:-no}" || exit 1
 
 # These are required.
 postconf "relayhost = ${SMTP_RELAY_HOST}" || exit 1


### PR DESCRIPTION
Hello,

I added "smtp_use_tls" option to allow tls usage.
I placed by default this option on "no" like default behavior in postfix.

Regards,
jgalais