### PR TITLE
Add feature to custom message size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This image supports the following enironment variables. All are **required**.
 | `SMTP_RELAY_MYNETWORKS`    | Comma-separated list of local networks that can use this SMTP relay | `127.0.0.0/8,10.0.0.0/8`  |
 | `SMTP_RELAY_WRAPPERMODE`   | Request postfix connects using SUBMISSIONS/SMTPS protocol instead of STARTTLS | `no`                      |
 | `SMTP_TLS_SECURITY_LEVEL`  | default SMTP TLS security level for the Postfix SMTP client         | `""`                      |
+| `SMTP_MESSAGE_SIZE_LIMIT`  | default SMTP message_size_limit (Example: 10MB)      		   | `10240000`                |
 
 # Quickstart
 Run on docker
@@ -31,6 +32,7 @@ docker run --rm -it -p 2525:25 \
 	-e SMTP_RELAY_MYNETWORKS=127.0.0.0/8,10.0.0.0/8 \
 	-e SMTP_RELAY_WRAPPERMODE=no \
 	-e SMTP_TLS_SECURITY_LEVEL="" \
+	-e SMTP_MESSAGE_SIZE_LIMIT=10240000 \
 	djjudas21/smtp-relay
 
 ```

--- a/smtp-relay.sh
+++ b/smtp-relay.sh
@@ -7,6 +7,8 @@ SMTP_RELAY_PASSWORD=${SMTP_RELAY_PASSWORD?Missing env var SMTP_RELAY_PASSWORD}
 SMTP_RELAY_MYNETWORKS=${SMTP_RELAY_MYNETWORKS?Missing env var SMTP_RELAY_MYNETWORKS}
 SMTP_RELAY_WRAPPERMODE=${SMTP_RELAY_WRAPPERMODE?Missing env var SMTP_RELAY_WRAPPERMODE}
 SMTP_TLS_SECURITY_LEVEL=${SMTP_TLS_SECURITY_LEVEL?Missing env var SMTP_TLS_SECURITY_LEVEL}
+# Message Size Limit
+SMTP_MESSAGE_SIZE_LIMIT=${SMTP_MESSAGE_SIZE_LIMIT?Missing env var SMTP_MESSAGE_SIZE_LIMIT}
 
 
 # handle sasl
@@ -24,6 +26,8 @@ postconf "myhostname = ${SMTP_RELAY_MYHOSTNAME}" || exit 1
 postconf "mynetworks = ${SMTP_RELAY_MYNETWORKS}" || exit 1
 postconf "smtp_tls_wrappermode = ${SMTP_RELAY_WRAPPERMODE}" || exit 1
 postconf "smtp_tls_security_level = ${SMTP_TLS_SECURITY_LEVEL}" || exit 1
+# Message Size Limit
+postconf "message_size_limit = ${SMTP_MESSAGE_SIZE_LIMIT}" || exit 1
 
 # http://www.postfix.org/COMPATIBILITY_README.html#smtputf8_enable
 postconf 'smtputf8_enable = no' || exit 1


### PR DESCRIPTION
I had installed helm chart of your smtp-relay in my Kubernetes to server webmail app. When I tested to sent big attachment (my webmail allowed up to 20MB attachment), the smtp-relay refuse to deliver because message_size_limit at about 10MB.
